### PR TITLE
fix: remove crash in `Pixels.renderLevel`

### DIFF
--- a/fabric/1.21/src/main/java/com/midnightbits/scanner/fabric/Pixels.java
+++ b/fabric/1.21/src/main/java/com/midnightbits/scanner/fabric/Pixels.java
@@ -96,8 +96,9 @@ public class Pixels {
                 nugget.sketch(glProgram, matrices, cameraPos);
             }
 
+            final var centralNugget = central == null ? null : central.nugget();
             for (final var nugget : visibleNuggets) {
-                if (nugget == central.nugget())
+                if (nugget == centralNugget)
                     continue;
                 nugget.sketch(glProgram, matrices, cameraPos);
             }


### PR DESCRIPTION
fixes: #27